### PR TITLE
Report the Azure error code as the Flysystem failure reason

### DIFF
--- a/src/Storage/BlobFlysystem/AzureBlobStorageAdapter.php
+++ b/src/Storage/BlobFlysystem/AzureBlobStorageAdapter.php
@@ -322,14 +322,18 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
      * what callers need to tell a missing blob apart from an authorization or throttling failure,
      * so it is prefixed to the service message rather than left only on the previous exception.
      *
-     * @param  \Throwable  $e  The exception raised by the Blob SDK.
+     * @param  \Throwable  $e  The exception raised by the Blob SDK, possibly wrapped by Flysystem.
      * @return string The reason, prefixed with the Azure error code when one is available.
      */
     private static function exceptionReason(\Throwable $e): string
     {
-        if ($e instanceof BlobStorageException && $e->errorCodeValue !== null) {
-            return $e->errorCodeValue.': '.$e->getMessage();
-        }
+        $cause = $e;
+
+        do {
+            if ($cause instanceof BlobStorageException && $cause->errorCodeValue !== null) {
+                return $cause->errorCodeValue.': '.$cause->getMessage();
+            }
+        } while ($cause = $cause->getPrevious());
 
         return $e->getMessage();
     }

--- a/src/Storage/BlobFlysystem/AzureBlobStorageAdapter.php
+++ b/src/Storage/BlobFlysystem/AzureBlobStorageAdapter.php
@@ -6,6 +6,7 @@ namespace AzureOss\Storage\BlobFlysystem;
 
 use AzureOss\Storage\Blob\BlobClient;
 use AzureOss\Storage\Blob\BlobContainerClient;
+use AzureOss\Storage\Blob\Exceptions\BlobStorageException;
 use AzureOss\Storage\Blob\Exceptions\UnableToGenerateSasException;
 use AzureOss\Storage\Blob\Models\Blob;
 use AzureOss\Storage\Blob\Models\BlobProperties;
@@ -120,7 +121,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
                 ->getBlobClient($this->prefixer->prefixPath($path))
                 ->upload($contents, $options);
         } catch (\Throwable $e) {
-            throw UnableToWriteFile::atLocation($path, previous: $e);
+            throw UnableToWriteFile::atLocation($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -208,7 +209,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
 
             return $result->content->getContents();
         } catch (\Throwable $e) {
-            throw UnableToReadFile::fromLocation($path, previous: $e);
+            throw UnableToReadFile::fromLocation($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -227,7 +228,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
 
             return $resource;
         } catch (\Throwable $e) {
-            throw UnableToReadFile::fromLocation($path, previous: $e);
+            throw UnableToReadFile::fromLocation($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -238,7 +239,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
                 ->getBlobClient($this->prefixer->prefixPath($path))
                 ->deleteIfExists();
         } catch (\Throwable $e) {
-            throw UnableToDeleteFile::atLocation($path, previous: $e);
+            throw UnableToDeleteFile::atLocation($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -253,7 +254,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
                 }
             }
         } catch (\Throwable $e) {
-            throw UnableToDeleteDirectory::atLocation($path, previous: $e);
+            throw UnableToDeleteDirectory::atLocation($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -279,7 +280,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
         try {
             return $this->fetchMetadata($path);
         } catch (\Throwable $e) {
-            throw UnableToRetrieveMetadata::mimeType($path, previous: $e);
+            throw UnableToRetrieveMetadata::mimeType($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -288,7 +289,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
         try {
             return $this->fetchMetadata($path);
         } catch (\Throwable $e) {
-            throw UnableToRetrieveMetadata::lastModified($path, previous: $e);
+            throw UnableToRetrieveMetadata::lastModified($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -297,7 +298,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
         try {
             return $this->fetchMetadata($path);
         } catch (\Throwable $e) {
-            throw UnableToRetrieveMetadata::lastModified($path, previous: $e);
+            throw UnableToRetrieveMetadata::lastModified($path, self::exceptionReason($e), $e);
         }
     }
 
@@ -310,6 +311,27 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
             ->getProperties();
 
         return $this->normalizeBlob($path, $properties);
+    }
+
+    /**
+     * Builds the reason reported on a Flysystem exception.
+     *
+     * Flysystem exposes the cause of a failure through `reason()`, which is also the value
+     * `MountManager` forwards when it re-throws. A `BlobStorageException` carries the Azure error
+     * code - `BlobNotFound`, `AuthorizationPermissionMismatch`, `ServerBusy` and so on - which is
+     * what callers need to tell a missing blob apart from an authorization or throttling failure,
+     * so it is prefixed to the service message rather than left only on the previous exception.
+     *
+     * @param  \Throwable  $e  The exception raised by the Blob SDK.
+     * @return string The reason, prefixed with the Azure error code when one is available.
+     */
+    private static function exceptionReason(\Throwable $e): string
+    {
+        if ($e instanceof BlobStorageException && $e->errorCodeValue !== null) {
+            return $e->errorCodeValue.': '.$e->getMessage();
+        }
+
+        return $e->getMessage();
     }
 
     public function listContents(string $path, bool $deep): iterable
@@ -497,7 +519,7 @@ final class AzureBlobStorageAdapter implements ChecksumProvider, FilesystemAdapt
                 ->getBlobClient($this->prefixer->prefixPath($path))
                 ->getProperties();
         } catch (\Throwable $e) {
-            throw new UnableToProvideChecksum($e->getMessage(), $path, $e);
+            throw new UnableToProvideChecksum(self::exceptionReason($e), $path, $e);
         }
 
         $md5 = $properties->contentMD5;

--- a/src/Storage/BlobFlysystem/CHANGELOG.md
+++ b/src/Storage/BlobFlysystem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Flysystem exceptions raised by the adapter now carry a reason. Where the underlying failure is a `BlobStorageException`, the reason is prefixed with the Azure error code (for example `BlobNotFound`), so callers can distinguish a missing blob from an authorization or throttling failure without unwrapping `getPrevious()`.
+
 ## 2.2.0
 
 ### Changed

--- a/tests/Storage/BlobFlysystem/Integration/AzureBlobStorageTest.php
+++ b/tests/Storage/BlobFlysystem/Integration/AzureBlobStorageTest.php
@@ -6,11 +6,13 @@ namespace AzureOss\Tests\Storage\BlobFlysystem\Integration;
 
 use AzureOss\Storage\Blob\BlobContainerClient;
 use AzureOss\Storage\Blob\BlobServiceClient;
+use AzureOss\Storage\Blob\Models\BlobErrorCode;
 use AzureOss\Storage\BlobFlysystem\AzureBlobStorageAdapter;
 use AzureOss\Tests\RequiresEnvironmentVariables;
 use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase;
 use League\Flysystem\Config;
 use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
 use PHPUnit\Framework\Attributes\Test;
@@ -234,6 +236,22 @@ class AzureBlobStorageTest extends FilesystemAdapterTestCase
             self::fail('Expected overwriting an existing file to fail.');
         } catch (UnableToWriteFile) {
             self::assertSame('original', $adapter->read('create-only.txt'));
+        }
+    }
+
+    #[Test]
+    public function it_reports_the_azure_error_code_as_the_failure_reason(): void
+    {
+        $adapter = $this->adapter();
+
+        try {
+            $adapter->read('does-not-exist.txt');
+            self::fail('Expected reading a missing blob to fail.');
+        } catch (UnableToReadFile $exception) {
+            self::assertStringContainsString(
+                BlobErrorCode::BlobNotFound->value,
+                $exception->reason(),
+            );
         }
     }
 

--- a/tests/Storage/BlobFlysystem/Integration/AzureBlobStorageTest.php
+++ b/tests/Storage/BlobFlysystem/Integration/AzureBlobStorageTest.php
@@ -12,6 +12,8 @@ use AzureOss\Tests\RequiresEnvironmentVariables;
 use League\Flysystem\AdapterTestUtilities\FilesystemAdapterTestCase;
 use League\Flysystem\Config;
 use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\UnableToDeleteDirectory;
+use League\Flysystem\UnableToListContents;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToWriteFile;
 use League\Flysystem\Visibility;
@@ -250,6 +252,26 @@ class AzureBlobStorageTest extends FilesystemAdapterTestCase
         } catch (UnableToReadFile $exception) {
             self::assertStringContainsString(
                 BlobErrorCode::BlobNotFound->value,
+                $exception->reason(),
+            );
+        }
+    }
+
+    #[Test]
+    public function it_reports_a_nested_azure_error_code_as_the_failure_reason(): void
+    {
+        $connectionString = self::getRequiredEnvironmentVariable('AZURE_STORAGE_CONNECTION_STRING');
+        $containerClient = BlobServiceClient::fromConnectionString($connectionString)
+            ->getContainerClient('missing-'.bin2hex(random_bytes(8)));
+        $adapter = new AzureBlobStorageAdapter($containerClient);
+
+        try {
+            $adapter->deleteDirectory('docs');
+            self::fail('Expected deleting from a missing container to fail.');
+        } catch (UnableToDeleteDirectory $exception) {
+            self::assertInstanceOf(UnableToListContents::class, $exception->getPrevious());
+            self::assertStringContainsString(
+                BlobErrorCode::ContainerNotFound->value,
                 $exception->reason(),
             );
         }

--- a/tests/Storage/BlobFlysystem/Unit/AzureBlobStorageAdapterTest.php
+++ b/tests/Storage/BlobFlysystem/Unit/AzureBlobStorageAdapterTest.php
@@ -54,6 +54,10 @@ final class AzureBlobStorageAdapterTest extends TestCase
                 'initialTransferSize must be an int.',
                 $exception->getPrevious()?->getMessage(),
             );
+            self::assertSame(
+                'initialTransferSize must be an int.',
+                $exception->reason(),
+            );
         }
     }
 

--- a/tests/Storage/BlobFlysystem/Unit/AzureBlobStorageAdapterTest.php
+++ b/tests/Storage/BlobFlysystem/Unit/AzureBlobStorageAdapterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AzureOss\Tests\Storage\BlobFlysystem\Unit;
 
 use AzureOss\Storage\Blob\BlobContainerClient;
+use AzureOss\Storage\Blob\Exceptions\BlobStorageException;
 use AzureOss\Storage\Blob\Models\BlobContainerClientOptions;
 use AzureOss\Storage\BlobFlysystem\AzureBlobStorageAdapter;
 use AzureOss\Storage\Common\Auth\StorageSharedKeyCredential;
@@ -13,6 +14,7 @@ use GuzzleHttp\Psr7\Uri;
 use League\Flysystem\ChecksumAlgoIsNotSupported;
 use League\Flysystem\Config;
 use League\Flysystem\UnableToGenerateTemporaryUrl;
+use League\Flysystem\UnableToListContents;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UnableToWriteFile;
 use PHPUnit\Framework\TestCase;
@@ -78,6 +80,22 @@ final class AzureBlobStorageAdapterTest extends TestCase
                 $exception->getPrevious()?->getMessage(),
             );
         }
+    }
+
+    public function test_exception_reason_uses_a_nested_blob_storage_exception(): void
+    {
+        $blobException = new BlobStorageException(
+            'The specified container does not exist.',
+            errorCodeValue: 'ContainerNotFound',
+        );
+        $nestedException = UnableToListContents::atLocation('docs', true, $blobException);
+        $outerException = new \RuntimeException('Outer wrapper.', previous: $nestedException);
+        $method = new \ReflectionMethod(AzureBlobStorageAdapter::class, 'exceptionReason');
+
+        self::assertSame(
+            'ContainerNotFound: The specified container does not exist.',
+            $method->invoke(null, $outerException),
+        );
     }
 
     public function test_public_url_uses_the_prefixed_blob_uri_for_public_containers(): void


### PR DESCRIPTION
## Problem

`AzureBlobStorageAdapter` converts SDK failures into Flysystem exceptions using only the named `previous:` argument:

```php
// src/Storage/BlobFlysystem/AzureBlobStorageAdapter.php
throw UnableToReadFile::fromLocation($path, previous: $e);
```

`UnableToReadFile::fromLocation()` takes `(string $location, string $reason = '', ?Throwable $previous = null)`, so `reason()` is left empty and the exception message is just:

```
Unable to read file from location: some/path.
```

That is unfortunate here specifically, because the SDK already has the information callers need. `BlobStorageException` carries `errorCode`, `errorCodeValue`, `statusCode` and `requestId`, so the difference between `BlobNotFound`, `AuthorizationPermissionMismatch` and `ServerBusy` is known at the throw site and then discarded from everything except `getPrevious()`.

The practical consequence is that a caller wanting to distinguish "blob is missing" (fall back / regenerate) from "auth or throttling failure" (surface, retry, alert) has to unwrap `getPrevious()` and type-check against the SDK — which defeats the point of coding against the Flysystem interface. It also matters inside Flysystem itself: `MountManager` re-throws with `$exception->reason()`, so an empty reason propagates as an empty reason.

`checksum()` in this same file already passes `$e->getMessage()`, so the adapter was internally inconsistent too.

## Change

Route the throw sites through a small private helper that prefixes the Azure error code to the service message when the cause is a `BlobStorageException`, and falls back to `getMessage()` otherwise:

```php
private static function exceptionReason(\Throwable $e): string
{
    if ($e instanceof BlobStorageException && $e->errorCodeValue !== null) {
        return $e->errorCodeValue.': '.$e->getMessage();
    }

    return $e->getMessage();
}
```

Applied to `write`, `read`, `readStream`, `delete`, `deleteDirectory`, `mimeType`, `lastModified`, `fileSize` and `checksum`. `$previous` is still set everywhere, so nothing that inspects it today breaks. No signature or behavior changes beyond the reason string being populated.

This also aligns the adapter with the other Flysystem adapters — `Local`, `GoogleCloudStorage` and the built-in `AzureBlobStorage` all populate the reason. I've opened thephpleague/flysystem#1913 to fix the same gap in `AwsS3V3Adapter`.

## Tests

- Integration (`tests/Storage/BlobFlysystem/Integration`): `it_reports_the_azure_error_code_as_the_failure_reason()` reads a missing blob and asserts `BlobNotFound` appears in `reason()`.
- Unit (`tests/Storage/BlobFlysystem/Unit`): extended the existing invalid-transfer-size test to assert the reason is populated on the non-`BlobStorageException` path.

Verified locally against Azurite (`mcr.microsoft.com/azure-storage/azurite`) on PHP 8.3:

- `vendor/bin/phpunit tests/Storage/BlobFlysystem` — 71 tests, 120 assertions, all passing.
- The new integration test fails without the adapter change (`Failed asserting that '' contains "BlobNotFound"`), so it is not vacuous.
- `vendor/bin/pint --test` — passed.
- `vendor/bin/phpstan --no-progress --memory-limit=2G` — the 4 reported errors are pre-existing on a clean checkout (`property.unused` in `tests/Storage/Blob/{Functional,Integration}/BlobClientTest.php`); none are in the files touched here.

`CHANGELOG.md` for the package is updated under `Unreleased`. Nothing here is breaking, so `UPGRADE.md` is untouched.

## Unrelated observation

While in the file: `fileSize()` throws `UnableToRetrieveMetadata::lastModified($path, ...)` rather than `::fileSize(...)`, so a failing `fileSize()` call reports itself as a last-modified failure. I left it alone to keep this PR to one concern — happy to send a separate PR if you'd like.