### PR TITLE
Add Queue Storage peek message support

### DIFF
--- a/docs/docs/5-storage-queue/0-overview.md
+++ b/docs/docs/5-storage-queue/0-overview.md
@@ -22,22 +22,8 @@ title: Overview
 - Messages:
   - Send messages (with optional visibility timeout and TTL)
   - Receive one or multiple messages
-  - Peek at one or multiple messages without changing their visibility
   - Delete messages
   - Update messages (including visibility timeout)
-
-## Peek at messages
-
-Peeking retrieves visible messages without changing their visibility or incrementing their dequeue count.
-Peeked messages do not include a pop receipt and therefore cannot be deleted or updated.
-
-```php
-$message = $queue->peekMessage();
-
-if ($message !== null) {
-    echo $message->body;
-}
-```
 
 ## Notes
 

--- a/docs/docs/5-storage-queue/0-overview.md
+++ b/docs/docs/5-storage-queue/0-overview.md
@@ -22,6 +22,7 @@ title: Overview
 - Messages:
   - Send messages (with optional visibility timeout and TTL)
   - Receive one or multiple messages
+  - Peek at one or multiple messages without changing their visibility
   - Delete messages
   - Update messages (including visibility timeout)
 

--- a/docs/docs/5-storage-queue/0-overview.md
+++ b/docs/docs/5-storage-queue/0-overview.md
@@ -26,6 +26,19 @@ title: Overview
   - Delete messages
   - Update messages (including visibility timeout)
 
+## Peek at messages
+
+Peeking retrieves visible messages without changing their visibility or incrementing their dequeue count.
+Peeked messages do not include a pop receipt and therefore cannot be deleted or updated.
+
+```php
+$message = $queue->peekMessage();
+
+if ($message !== null) {
+    echo $message->body;
+}
+```
+
 ## Notes
 
 - SAS authentication is supported, but SAS generation is not supported yet in this SDK.

--- a/src/Storage/Queue/CHANGELOG.md
+++ b/src/Storage/Queue/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-No user-facing changes since `1.2.0`.
+### Added
+
+- Added `QueueClient::peekMessage()`, `peekMessageAsync()`, `peekMessages()`, and `peekMessagesAsync()` for inspecting visible messages without changing their visibility.
 
 ## 1.2.0
 

--- a/src/Storage/Queue/Models/PeekedMessage.php
+++ b/src/Storage/Queue/Models/PeekedMessage.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Queue\Models;
+
+use AzureOss\Storage\Queue\Exceptions\DeserializationException;
+
+/**
+ * Represents an Azure Storage queue message inspected without changing its visibility.
+ *
+ * Peeked messages do not include a pop receipt and therefore cannot be deleted or updated.
+ */
+final class PeekedMessage
+{
+    private function __construct(
+        public readonly string $messageId,
+        public readonly string $messageText,
+        public readonly \DateTimeInterface $insertionTime,
+        public readonly \DateTimeInterface $expirationTime,
+        public readonly int $dequeueCount,
+    ) {}
+
+    public static function fromXml(\SimpleXMLElement $xml): self
+    {
+        $insertionTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC1123, (string) $xml->InsertionTime);
+        if ($insertionTime === false) {
+            throw new DeserializationException('Azure returned a malformed date.');
+        }
+
+        $expirationTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC1123, (string) $xml->ExpirationTime);
+        if ($expirationTime === false) {
+            throw new DeserializationException('Azure returned a malformed date.');
+        }
+
+        return new self(
+            (string) $xml->MessageId,
+            (string) $xml->MessageText,
+            $insertionTime,
+            $expirationTime,
+            (int) $xml->DequeueCount,
+        );
+    }
+}

--- a/src/Storage/Queue/Models/PeekedMessage.php
+++ b/src/Storage/Queue/Models/PeekedMessage.php
@@ -15,29 +15,29 @@ final class PeekedMessage
 {
     private function __construct(
         public readonly string $messageId,
-        public readonly string $messageText,
-        public readonly \DateTimeInterface $insertionTime,
-        public readonly \DateTimeInterface $expirationTime,
+        public readonly string $body,
+        public readonly ?\DateTimeInterface $insertedOn,
+        public readonly ?\DateTimeInterface $expiresOn,
         public readonly int $dequeueCount,
     ) {}
 
     public static function fromXml(\SimpleXMLElement $xml): self
     {
-        $insertionTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC1123, (string) $xml->InsertionTime);
-        if ($insertionTime === false) {
+        $insertedOn = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC1123, (string) $xml->InsertionTime);
+        if ($insertedOn === false) {
             throw new DeserializationException('Azure returned a malformed date.');
         }
 
-        $expirationTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC1123, (string) $xml->ExpirationTime);
-        if ($expirationTime === false) {
+        $expiresOn = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC1123, (string) $xml->ExpirationTime);
+        if ($expiresOn === false) {
             throw new DeserializationException('Azure returned a malformed date.');
         }
 
         return new self(
             (string) $xml->MessageId,
             (string) $xml->MessageText,
-            $insertionTime,
-            $expirationTime,
+            $insertedOn,
+            $expiresOn,
             (int) $xml->DequeueCount,
         );
     }

--- a/src/Storage/Queue/QueueClient.php
+++ b/src/Storage/Queue/QueueClient.php
@@ -10,6 +10,7 @@ use AzureOss\Storage\Common\Helpers\HttpRequestHelper;
 use AzureOss\Storage\Common\Middleware\ClientFactory;
 use AzureOss\Storage\Queue\Exceptions\QueueStorageException;
 use AzureOss\Storage\Queue\Exceptions\QueueStorageExceptionDeserializer;
+use AzureOss\Storage\Queue\Models\PeekedMessage;
 use AzureOss\Storage\Queue\Models\QueueClientOptions;
 use AzureOss\Storage\Queue\Models\QueueErrorCode;
 use AzureOss\Storage\Queue\Models\QueueMessage;
@@ -17,6 +18,7 @@ use AzureOss\Storage\Queue\Models\QueueProperties;
 use AzureOss\Storage\Queue\Models\SendReceipt;
 use AzureOss\Storage\Queue\Models\UpdateReceipt;
 use AzureOss\Storage\Queue\Requests\QueueMessageRequestBody;
+use AzureOss\Storage\Queue\Responses\PeekMessagesResponseBody;
 use AzureOss\Storage\Queue\Responses\ReceiveMessagesResponseBody;
 use AzureOss\Storage\Queue\Responses\SendMessageResponseBody;
 use AzureOss\Storage\Queue\Responses\UpdateMessageResponseBody;
@@ -315,6 +317,55 @@ final class QueueClient
                 RequestOptions::QUERY => $query,
             ])
             ->then(ReceiveMessagesResponseBody::fromResponse(...));
+    }
+
+    /** Peeks at the next visible message without changing its visibility, or returns null when none is available. */
+    public function peekMessage(): ?PeekedMessage
+    {
+        return $this->peekMessageAsync()->wait();
+    }
+
+    /**
+     * Asynchronously peeks at the next visible message without changing its visibility.
+     *
+     * @return PromiseInterface<PeekedMessage|null, mixed>
+     */
+    public function peekMessageAsync(): PromiseInterface
+    {
+        return $this->peekMessagesAsync(1)
+            ->then(fn (array $messages): ?PeekedMessage => $messages[0] ?? null);
+    }
+
+    /**
+     * Peeks at up to the requested number of visible messages without changing their visibility.
+     *
+     * @param  int|null  $maxMessages  Maximum messages to peek; Azure Storage accepts 1 through 32.
+     * @return PeekedMessage[]
+     */
+    public function peekMessages(?int $maxMessages = null): array
+    {
+        return $this->peekMessagesAsync($maxMessages)->wait();
+    }
+
+    /**
+     * Asynchronously peeks at a batch of visible messages without changing their visibility.
+     *
+     * @return PromiseInterface<array<PeekedMessage>, mixed>
+     */
+    public function peekMessagesAsync(?int $maxMessages = null): PromiseInterface
+    {
+        $query = [
+            'peekonly' => 'true',
+        ];
+        if ($maxMessages !== null) {
+            $query['numofmessages'] = $maxMessages;
+        }
+
+        return $this->client
+            ->getAsync($this->messagesUri(), [
+                RequestOptions::QUERY => $query,
+            ])
+            ->then(PeekMessagesResponseBody::fromResponse(...));
     }
 
     private function messagesUri(): UriInterface

--- a/src/Storage/Queue/README.md
+++ b/src/Storage/Queue/README.md
@@ -30,6 +30,11 @@ $queue->createIfNotExists();
 
 $queue->sendMessage('Hello from PHP OSS for Azure');
 
+$peekedMessage = $queue->peekMessage();
+if ($peekedMessage !== null) {
+    echo $peekedMessage->body.PHP_EOL;
+}
+
 $message = $queue->receiveMessage(30);
 if ($message !== null) {
     echo $message->messageText.PHP_EOL;

--- a/src/Storage/Queue/README.md
+++ b/src/Storage/Queue/README.md
@@ -54,6 +54,7 @@ $queue->deleteIfExists();
 - Messages:
   - Send messages (with optional visibility timeout and TTL)
   - Receive one or multiple messages (with visibility timeout)
+  - Peek at one or multiple messages without changing their visibility
   - Delete messages
   - Update messages (including visibility timeout)
 

--- a/src/Storage/Queue/README.md
+++ b/src/Storage/Queue/README.md
@@ -30,11 +30,6 @@ $queue->createIfNotExists();
 
 $queue->sendMessage('Hello from PHP OSS for Azure');
 
-$peekedMessage = $queue->peekMessage();
-if ($peekedMessage !== null) {
-    echo $peekedMessage->body.PHP_EOL;
-}
-
 $message = $queue->receiveMessage(30);
 if ($message !== null) {
     echo $message->messageText.PHP_EOL;
@@ -59,7 +54,6 @@ $queue->deleteIfExists();
 - Messages:
   - Send messages (with optional visibility timeout and TTL)
   - Receive one or multiple messages (with visibility timeout)
-  - Peek at one or multiple messages without changing their visibility
   - Delete messages
   - Update messages (including visibility timeout)
 

--- a/src/Storage/Queue/README.md
+++ b/src/Storage/Queue/README.md
@@ -59,6 +59,7 @@ $queue->deleteIfExists();
 - Messages:
   - Send messages (with optional visibility timeout and TTL)
   - Receive one or multiple messages (with visibility timeout)
+  - Peek at one or multiple messages without changing their visibility
   - Delete messages
   - Update messages (including visibility timeout)
 

--- a/src/Storage/Queue/Responses/PeekMessagesResponseBody.php
+++ b/src/Storage/Queue/Responses/PeekMessagesResponseBody.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Queue\Responses;
+
+use AzureOss\Storage\Queue\Models\PeekedMessage;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @internal
+ */
+final class PeekMessagesResponseBody
+{
+    /**
+     * @param  PeekedMessage[]  $messages
+     */
+    private function __construct(
+        public readonly array $messages,
+    ) {}
+
+    /**
+     * @return PeekedMessage[]
+     */
+    public static function fromResponse(ResponseInterface $response): array
+    {
+        return self::fromXml(new \SimpleXMLElement($response->getBody()->getContents()))->messages;
+    }
+
+    public static function fromXml(\SimpleXMLElement $xml): self
+    {
+        $messages = [];
+        foreach ($xml->QueueMessage as $message) {
+            $messages[] = PeekedMessage::fromXml($message);
+        }
+
+        return new self($messages);
+    }
+}

--- a/tests/Storage/Queue/Integration/QueueClientTest.php
+++ b/tests/Storage/Queue/Integration/QueueClientTest.php
@@ -228,7 +228,13 @@ final class QueueClientTest extends TestCase
         $peekedMessage = $queue->peekMessage();
 
         self::assertNotNull($peekedMessage);
-        self::assertSame('test-1', $peekedMessage->messageText);
+        self::assertSame('test-1', $peekedMessage->body);
+
+        $peekedAgain = $queue->peekMessage();
+
+        self::assertNotNull($peekedAgain);
+        self::assertSame($peekedMessage->messageId, $peekedAgain->messageId);
+        self::assertSame($peekedMessage->dequeueCount, $peekedAgain->dequeueCount);
 
         $receivedMessage = $queue->receiveMessage();
 
@@ -254,6 +260,16 @@ final class QueueClientTest extends TestCase
             array_column($peekedMessages, 'messageId'),
             array_column($receivedMessages, 'messageId'),
         );
+    }
+
+    #[Test]
+    public function peek_messages_defaults_to_one_message(): void
+    {
+        $queue = $this->tempQueue();
+        $queue->sendMessage('test-1');
+        $queue->sendMessage('test-2');
+
+        self::assertCount(1, $queue->peekMessages());
     }
 
     #[Test]

--- a/tests/Storage/Queue/Integration/QueueClientTest.php
+++ b/tests/Storage/Queue/Integration/QueueClientTest.php
@@ -220,6 +220,51 @@ final class QueueClientTest extends TestCase
     }
 
     #[Test]
+    public function peek_message_works_without_changing_message_visibility(): void
+    {
+        $queue = $this->tempQueue();
+        $queue->sendMessage('test-1');
+
+        $peekedMessage = $queue->peekMessage();
+
+        self::assertNotNull($peekedMessage);
+        self::assertSame('test-1', $peekedMessage->messageText);
+
+        $receivedMessage = $queue->receiveMessage();
+
+        self::assertNotNull($receivedMessage);
+        self::assertSame($peekedMessage->messageId, $receivedMessage->messageId);
+    }
+
+    #[Test]
+    public function peek_messages_works_without_changing_message_visibility(): void
+    {
+        $queue = $this->tempQueue();
+        $queue->sendMessage('test-1');
+        $queue->sendMessage('test-2');
+
+        $peekedMessages = $queue->peekMessages(maxMessages: 2);
+
+        self::assertCount(2, $peekedMessages);
+
+        $receivedMessages = $queue->receiveMessages(maxMessages: 2);
+
+        self::assertCount(2, $receivedMessages);
+        self::assertEqualsCanonicalizing(
+            array_column($peekedMessages, 'messageId'),
+            array_column($receivedMessages, 'messageId'),
+        );
+    }
+
+    #[Test]
+    public function peek_message_returns_null_when_queue_is_empty(): void
+    {
+        $queue = $this->tempQueue();
+
+        self::assertNull($queue->peekMessage());
+    }
+
+    #[Test]
     public function update_message_works(): void
     {
         $queue = $this->tempQueue();

--- a/tests/Storage/Queue/Unit/PeekMessagesResponseBodyTest.php
+++ b/tests/Storage/Queue/Unit/PeekMessagesResponseBodyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Tests\Storage\Queue\Unit;
+
+use AzureOss\Storage\Queue\Responses\PeekMessagesResponseBody;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PeekMessagesResponseBodyTest extends TestCase
+{
+    #[Test]
+    public function it_deserializes_messages_from_a_response(): void
+    {
+        $messages = PeekMessagesResponseBody::fromResponse(new Response(200, body: <<<'XML'
+            <QueueMessagesList>
+                <QueueMessage>
+                    <MessageId>message-id</MessageId>
+                    <InsertionTime>Sun, 27 Sep 2009 18:41:57 GMT</InsertionTime>
+                    <ExpirationTime>Sun, 04 Oct 2009 18:41:57 GMT</ExpirationTime>
+                    <DequeueCount>3</DequeueCount>
+                    <MessageText>hello world</MessageText>
+                </QueueMessage>
+            </QueueMessagesList>
+            XML));
+
+        self::assertCount(1, $messages);
+        self::assertSame('message-id', $messages[0]->messageId);
+        self::assertSame('hello world', $messages[0]->messageText);
+    }
+
+    #[Test]
+    public function it_deserializes_an_empty_message_list(): void
+    {
+        $body = PeekMessagesResponseBody::fromXml(new \SimpleXMLElement('<QueueMessagesList />'));
+
+        self::assertSame([], $body->messages);
+    }
+}

--- a/tests/Storage/Queue/Unit/PeekMessagesResponseBodyTest.php
+++ b/tests/Storage/Queue/Unit/PeekMessagesResponseBodyTest.php
@@ -28,7 +28,7 @@ final class PeekMessagesResponseBodyTest extends TestCase
 
         self::assertCount(1, $messages);
         self::assertSame('message-id', $messages[0]->messageId);
-        self::assertSame('hello world', $messages[0]->messageText);
+        self::assertSame('hello world', $messages[0]->body);
     }
 
     #[Test]

--- a/tests/Storage/Queue/Unit/PeekedMessageTest.php
+++ b/tests/Storage/Queue/Unit/PeekedMessageTest.php
@@ -24,9 +24,9 @@ final class PeekedMessageTest extends TestCase
             XML));
 
         self::assertSame('message-id', $message->messageId);
-        self::assertSame('PHNhbXBsZT5tZXNzYWdlPC9zYW1wbGU+', $message->messageText);
-        self::assertSame('2009-09-27T18:41:57+00:00', $message->insertionTime->format(\DateTimeInterface::ATOM));
-        self::assertSame('2009-10-04T18:41:57+00:00', $message->expirationTime->format(\DateTimeInterface::ATOM));
+        self::assertSame('PHNhbXBsZT5tZXNzYWdlPC9zYW1wbGU+', $message->body);
+        self::assertSame('2009-09-27T18:41:57+00:00', $message->insertedOn?->format(\DateTimeInterface::ATOM));
+        self::assertSame('2009-10-04T18:41:57+00:00', $message->expiresOn?->format(\DateTimeInterface::ATOM));
         self::assertSame(3, $message->dequeueCount);
     }
 }

--- a/tests/Storage/Queue/Unit/PeekedMessageTest.php
+++ b/tests/Storage/Queue/Unit/PeekedMessageTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Tests\Storage\Queue\Unit;
+
+use AzureOss\Storage\Queue\Models\PeekedMessage;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PeekedMessageTest extends TestCase
+{
+    #[Test]
+    public function it_deserializes_from_xml(): void
+    {
+        $message = PeekedMessage::fromXml(new \SimpleXMLElement(<<<'XML'
+            <QueueMessage>
+                <MessageId>message-id</MessageId>
+                <InsertionTime>Sun, 27 Sep 2009 18:41:57 GMT</InsertionTime>
+                <ExpirationTime>Sun, 04 Oct 2009 18:41:57 GMT</ExpirationTime>
+                <DequeueCount>3</DequeueCount>
+                <MessageText>PHNhbXBsZT5tZXNzYWdlPC9zYW1wbGU+</MessageText>
+            </QueueMessage>
+            XML));
+
+        self::assertSame('message-id', $message->messageId);
+        self::assertSame('PHNhbXBsZT5tZXNzYWdlPC9zYW1wbGU+', $message->messageText);
+        self::assertSame('2009-09-27T18:41:57+00:00', $message->insertionTime->format(\DateTimeInterface::ATOM));
+        self::assertSame('2009-10-04T18:41:57+00:00', $message->expirationTime->format(\DateTimeInterface::ATOM));
+        self::assertSame(3, $message->dequeueCount);
+    }
+}


### PR DESCRIPTION
Closes #75 

## Summary

Adds support for inspecting visible Azure Storage Queue messages without changing their visibility.

The new API follows the existing synchronous/asynchronous method pairs used by `QueueClient`:

- `peekMessage()`
- `peekMessageAsync()`
- `peekMessages()`
- `peekMessagesAsync()`

A separate `PeekedMessage` model is used because the Azure Peek Messages response does not contain `PopReceipt` or `TimeNextVisible`. Peeked messages therefore cannot be passed directly to update or delete operations.

## Implementation

- Sends `GET /messages?peekonly=true`.
- Supports the optional `numofmessages` parameter.
- Returns `null` when `peekMessage()` finds no visible message.
- Deserializes message ID, text, insertion and expiration times, and dequeue count.
- Updates the Queue package README, documentation, and changelog.

REST API reference:
https://learn.microsoft.com/en-us/rest/api/storageservices/peek-messages

## Tests

Verified locally with PHP 8.5, Guzzle 8, and Azurite:

- Queue unit tests: 24 passed, 68 assertions.
- Queue integration tests: 22 passed, 40 assertions.
- Architecture tests: 8 passed, 86 assertions.
- PHPStan: passed with no errors.
- Pint: passed for all 260 files.
- `git diff --check`: passed.

The integration tests verify that:

- a peeked message remains immediately available to `receiveMessage()`;
- batch peeking does not change visibility;
- `peekMessage()` returns `null` for an empty queue.

## Compatibility

This is an additive change. No existing public API is modified and no upgrade instructions are required.

Before submitting, replace `#ISSUE` in the first line of the description with the actual issue number.
